### PR TITLE
Update link to example calendar in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ As a tutor of the [Insopor Zen Academy](http://insopor-zen-academy.com), I run
 the Sinopa Zen House. There is a daily meditation schedule that regularly
 updated on Meetup. However, I want that schedule also to be seen on our
 website. You can see this as a demo
-[here](insopor-zen-academy.com/zen-meditation-schedule/).
+[here](https://zen-temple.net/zen-temples/lambda-zen-temple/zen-meditation-schedule/).
 
 ## Use as a Service
 


### PR DESCRIPTION
the root url has changed, so I've updated it with a link that now send viewers to a page where the schedule is